### PR TITLE
Revert "Fetch origin master before using it"

### DIFF
--- a/versiune.sh
+++ b/versiune.sh
@@ -41,7 +41,6 @@ EOF
 
 #sha_is_on_master=$(git branch -r --contains $sha | grep origin/master)
 
-git fetch -q origin master
 
 current_sha=$(git rev-parse HEAD)
 master_sha=$(git merge-base origin/master $current_sha)


### PR DESCRIPTION
Reverts lstephen/docker-versiune#12

Using fetch does not work if we don't have permissions to the repo.
